### PR TITLE
prevent window deleting

### DIFF
--- a/ibuffer-sidebar.el
+++ b/ibuffer-sidebar.el
@@ -219,6 +219,7 @@ to disable automatic refresh when a special command is triggered."
     (display-buffer-in-side-window buffer ibuffer-sidebar-display-alist)
     (let ((window (get-buffer-window buffer)))
       (set-window-dedicated-p window t)
+      (set-window-parameter window 'no-delete-other-windows t)
       (with-selected-window window
         (let ((window-size-fixed))
           (ibuffer-sidebar-set-width ibuffer-sidebar-width))))


### PR DESCRIPTION
prevent delete ibuffer-sidebar window from other window. 
necessary when have 2 sidebar windows.